### PR TITLE
Removes "cool stuff" from Afinn-111 file. It was causing an error in problem 3

### DIFF
--- a/assignment1/AFINN-111.txt
+++ b/assignment1/AFINN-111.txt
@@ -337,7 +337,6 @@ calm	2
 calmed	2
 calming	2
 calms	2
-can't stand	-3
 cancel	-1
 cancelled	-1
 cancelling	-1
@@ -351,7 +350,6 @@ careful	2
 carefully	2
 careless	-2
 cares	2
-cashing in	-2
 casualty	-2
 catastrophe	-3
 catastrophic	-4
@@ -758,9 +756,7 @@ dithering	-2
 dizzy	-1
 dodging	-2
 dodgy	-2
-does not work	-3
 dolorous	-2
-dont like	-2
 doom	-2
 doomed	-2
 doubt	-1
@@ -975,7 +971,6 @@ fearful	-2
 fearing	-2
 fearless	2
 fearsome	-2
-fed up	-3
 feeble	-2
 feeling	1
 felonies	-3
@@ -1105,8 +1100,6 @@ greater	3
 greatest	3
 greed	-3
 greedy	-2
-green wash	-3
-green washing	-3
 greenwash	-3
 greenwasher	-3
 greenwashers	-3
@@ -1513,7 +1506,6 @@ mercy	2
 merry	3
 mess	-2
 messed	-2
-messing up	-2
 methodical	2
 mindless	-2
 miracle	4
@@ -1602,14 +1594,11 @@ nifty	2
 niggas	-5
 nigger	-5
 no	-1
-no fun	-3
 noble	2
 noisy	-1
 nonsense	-2
 noob	-2
 nosey	-2
-not good	-2
-not working	-3
 notorious	-2
 novel	2
 numb	-1
@@ -1918,7 +1907,6 @@ rich	2
 ridiculous	-3
 rig	-1
 rigged	-1
-right direction	3
 rigorous	3
 rigorously	3
 riot	-2
@@ -1976,7 +1964,6 @@ screamed	-2
 screaming	-2
 screams	-2
 screwed	-2
-screwed up	-3
 scumbag	-4
 secure	2
 secured	2
@@ -2070,7 +2057,6 @@ solved	1
 solves	1
 solving	1
 somber	-2
-some kind	0
 son-of-a-bitch	-5
 soothe	3
 soothed	3


### PR DESCRIPTION
This pull request does two things:
- Removes cool stuff from the sentiments file. If you maintained the words in the original sentiments dictionary for the solution of the problem 3, the system was showing an error:

![screen shot 2014-07-06 at 4 33 28 pm](https://cloud.githubusercontent.com/assets/1568357/3489893/d55aab2e-054c-11e4-8f40-e54cac7d8bb8.png)

The error was caused by that word.

(After checking the file, there were other multi-word phrases, this pull request also removes them)

List of words being removed:

```
cool stuff
green wash
messing up
does not work
can't stand
green washing
no fun
right direction
naïve
some kind
cashing in
not working
screwed up
dont like
fed up
not good
```
- Removes an extra space at the end of the file (There is another pull request for this)
