### PR TITLE
Some Twitter v1 endpoints were closed

### DIFF
--- a/assignment1/twitterstream.py
+++ b/assignment1/twitterstream.py
@@ -51,7 +51,7 @@ def twitterreq(url, method, parameters):
   return response
 
 def fetchsamples():
-  url = "https://stream.twitter.com/1/statuses/sample.json"
+  url = "https://stream.twitter.com/1.1/statuses/sample.json"
   parameters = []
   response = twitterreq(url, "GET", parameters)
   for line in response:


### PR DESCRIPTION
I updated v1 endpoints to version 1.1 so that they work after Twitter deprecated some v1 endpoints. Somebody also noted this in the forum of the course, but nobody seemed to change it in the git, so this is then change and pull request.