### PR TITLE
Twitter requires API version to be 1.1, not 1

### DIFF
--- a/assignment1/twitterstream.py
+++ b/assignment1/twitterstream.py
@@ -51,7 +51,7 @@ def twitterreq(url, method, parameters):
   return response
 
 def fetchsamples():
-  url = "https://stream.twitter.com/1/statuses/sample.json"
+  url = "https://stream.twitter.com/1.1/statuses/sample.json"
   parameters = []
   response = twitterreq(url, "GET", parameters)
   for line in response:


### PR DESCRIPTION
Twitter returns an "Unknown URL" error using API version 1 in the stream.twitter.com link.
