### PR TITLE
Update outdated twitter sample stream URL

### DIFF
--- a/assignment1/twitterstream.py
+++ b/assignment1/twitterstream.py
@@ -51,7 +51,7 @@ def twitterreq(url, method, parameters):
   return response
 
 def fetchsamples():
-  url = "https://stream.twitter.com/1/statuses/sample.json"
+  url = "https://stream.twitter.com/1.1/statuses/sample.json"
   parameters = []
   response = twitterreq(url, "GET", parameters)
   for line in response:


### PR DESCRIPTION
The old URL pointing to version one doesn't work anymore. After updating the version to 1.1 everything works like a charm.
